### PR TITLE
feat: Add filter option to eventCount method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ci-trap-web",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ci-trap-web",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ci-trap-web",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Lightweight mouse and touch event tracker library for browsers.",
   "main": "dist/trap-umd.min.js",
   "module": "src/trap.js",

--- a/src/buffer.js
+++ b/src/buffer.js
@@ -173,8 +173,8 @@ class Buffer {
   }
 
   // Returns the number of events
-  eventCount() {
-    return this._buffer.length;
+  eventCount(filterFn = () => true) {
+    return this._buffer.filter(filterFn).length;
   }
 }
 

--- a/src/inMemoryEventStorage.js
+++ b/src/inMemoryEventStorage.js
@@ -54,15 +54,20 @@ class InMemoryEventStorage {
 
   // Ensure there are at most sizeLimit events
   cleanUpInMemoryBufferIfNeeded() {
-    let eventCount = this.inMemoryEventStorage.reduce(
-      (acc, item) => acc + item.length,
-      0,
-    );
+    let eventCount = this.eventCount();
 
     while (eventCount > this.sizeLimit) {
       const item = this.inMemoryEventStorage.shift();
       eventCount -= item.length;
     }
+  }
+
+  // Return the number of events
+  eventCount(filterFn = () => true) {
+    return this.inMemoryEventStorage.reduce(
+      (acc, item) => acc + item.filter(filterFn).length,
+      0,
+    );
   }
 }
 

--- a/src/trap.js
+++ b/src/trap.js
@@ -70,7 +70,6 @@ class Trap {
       logger: (...m) => { console.log(...m); },
       transport: new HTTP(this._metadata, this._buffer),
       sequenceNumber: 0,
-      eventCount: 0,
       eventStorage: new InMemoryEventStorage(),
       collectEvents: false,
     };
@@ -258,7 +257,6 @@ class Trap {
     }
 
     const events = this._buffer.flush();
-    this.state.eventCount += events.length;
     if (!final) {
       this.addHeaderToBuffer();
     }
@@ -441,19 +439,22 @@ class Trap {
   }
 
   /**
-   * Return the number of events captured since start
+   * @typeDef filterFunction
+   * @param  {Array} item
+   * @returns  {boolean}
+   */
+
+  /**
+   * Returns the number of collected events. If `filterFn` is specified it
+   * returns only the events that match the specified filter.
+   *
+   * @param {filterFunction} filterFn
    *
    * @returns {int}
    */
-  eventCount() {
-    return this.state.eventCount + this._buffer.eventCount();
-  }
-
-  /**
-   * Reset event count
-   */
-  resetEventCount() {
-    this.state.eventCount = 0;
+  collectedEventCount(filterFn = () => true) {
+    return this.state.eventStorage.eventCount(filterFn)
+      + this._buffer.eventCount(filterFn);
   }
 
   /**

--- a/test/trap.in-memory-buffer.test.js
+++ b/test/trap.in-memory-buffer.test.js
@@ -47,6 +47,12 @@ describe('In-memory buffer tests', () => {
     // Manually invoke chunk submission
     trap.submit();
 
+    // Two submitted events
+    expect(trap.collectedEventCount()).toBe(2);
+
+    // One submitted custom event
+    expect(trap.collectedEventCount((item) => item[0] === 1)).toBe(1);
+
     // Get the collected events in the in-memory buffer
     const collectedEvents = trap.flushCollectedEvents();
 

--- a/test/trap.mouse-events.test.js
+++ b/test/trap.mouse-events.test.js
@@ -60,13 +60,19 @@ describe('browser with mouse events', () => {
     });
 
     // Two, not yet submitted events
-    expect(trap.eventCount()).toBe(2);
+    expect(trap.collectedEventCount()).toBe(2);
+
+    // Two mouse events
+    expect(trap.collectedEventCount((item) => item[0] === 0)).toBe(2);
+
+    // No custom event
+    expect(trap.collectedEventCount((item) => item[0] === 1)).toBe(0);
 
     // Manually trigger submit
     trap.submit();
 
-    // Two submitted events
-    expect(trap.eventCount()).toBe(2);
+    // Submitted events are not counted
+    expect(trap.collectedEventCount()).toBe(0);
 
     expect(fetch).toHaveBeenCalledTimes(1);
 
@@ -77,20 +83,14 @@ describe('browser with mouse events', () => {
       screenY: 6,
     });
 
-    // Two submitted, one not submitted event
-    expect(trap.eventCount()).toBe(3);
+    // One not submitted event
+    expect(trap.collectedEventCount()).toBe(1);
 
     // Manually trigger submit
     trap.submit(true);
 
     // Four submitted (3 mouse + 1 header)
-    expect(trap.eventCount()).toBe(4);
-
-    // Resets event count
-    trap.resetEventCount();
-
-    // Event count reseted
-    expect(trap.eventCount()).toBe(0);
+    expect(trap.collectedEventCount()).toBe(0);
   });
 
   test('triggers mouse down and up events', () => {


### PR DESCRIPTION
Also rename it to collectedEventCount as it only returns the count of in-memory collected events.