### PR TITLE
feat: Add option in Trap to retrieve a clone of the collected events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ci-trap-web",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ci-trap-web",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "fflate": "^0.8.0",
         "js-cookie": "^3.0.5",
         "platform": "^1.3.6",
+        "rfdc": "^1.4.1",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -4371,9 +4372,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -10112,6 +10113,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -14523,9 +14529,9 @@
       }
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",
@@ -18762,6 +18768,11 @@
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
+    },
+    "rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="
     },
     "rimraf": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "fflate": "^0.8.0",
     "js-cookie": "^3.0.5",
     "platform": "^1.3.6",
+    "rfdc": "^1.4.1",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ci-trap-web",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Lightweight mouse and touch event tracker library for browsers.",
   "main": "dist/trap-umd.min.js",
   "module": "src/trap.js",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -77,7 +77,7 @@ export default [{
   // CommonJS (for Node) and ES module (for bundlers) build
   input: 'src/trap.js',
 
-  external: ['fflate', 'js-cookie', 'platform', 'uuid'],
+  external: ['fflate', 'js-cookie', 'platform', 'rfdc/default', 'uuid'],
 
   output: [{
     file: 'dist/trap.min.js',

--- a/src/buffer.js
+++ b/src/buffer.js
@@ -7,6 +7,7 @@
 //
 // It also manages the enabled/disabled state.
 //------------------------------------------------------------------------------
+import clone from 'rfdc/default';
 
 import simpleAutoBind from './simpleAutoBind';
 import eventEmitterMixin from './eventEmitterMixin';
@@ -172,9 +173,9 @@ class Buffer {
     this._headerItems.length = 0;
   }
 
-  // Returns the number of events
-  eventCount(filterFn = () => true) {
-    return this._buffer.filter(filterFn).length;
+  // Returns a deep copy of the collected events
+  collectedEvents() {
+    return clone(this._buffer);
   }
 }
 

--- a/src/inMemoryEventStorage.js
+++ b/src/inMemoryEventStorage.js
@@ -5,9 +5,9 @@
 //------------------------------------------------------------------------------
 // In memory event storage for Cursor Insight's ligthweight mouse tracker.
 //------------------------------------------------------------------------------
+import clone from 'rfdc/default';
 
 import simpleAutoBind from './simpleAutoBind';
-
 import {
   DEFAULT_TRAP_IN_MEMORY_STORAGE_SIZE_LIMIT,
 } from './constants';
@@ -63,11 +63,16 @@ class InMemoryEventStorage {
   }
 
   // Return the number of events
-  eventCount(filterFn = () => true) {
+  eventCount() {
     return this.inMemoryEventStorage.reduce(
-      (acc, item) => acc + item.filter(filterFn).length,
+      (acc, item) => acc + item.length,
       0,
     );
+  }
+
+  // Returns a deep copy of the collected events
+  collectedEvents() {
+    return clone(this.inMemoryEventStorage.flat());
   }
 }
 

--- a/src/trap.js
+++ b/src/trap.js
@@ -450,22 +450,30 @@ class Trap {
   }
 
   /**
-   * @typeDef filterFunction
-   * @param  {Array} item
-   * @returns  {boolean}
+   * Returns a deep copy of the collected events while keeping them unchanged in
+   * Trap.
+   *
+   * @returns {undefined|Array<Array>}
    */
+  collectedEvents() {
+    return this.state.eventStorage.collectedEvents().concat(
+      this._buffer.collectedEvents(),
+    );
+  }
 
   /**
    * Returns the number of collected events. If `filterFn` is specified it
    * returns only the events that match the specified filter.
+   *
+   * @deprecated use collectedEvents instead and do the filtering and counting
+   * in the calling application.
    *
    * @param {filterFunction} filterFn
    *
    * @returns {int}
    */
   collectedEventCount(filterFn = () => true) {
-    return this.state.eventStorage.eventCount(filterFn)
-      + this._buffer.eventCount(filterFn);
+    return this.collectedEvents().filter(filterFn).length;
   }
 
   /**

--- a/test/trap.in-memory-buffer.test.js
+++ b/test/trap.in-memory-buffer.test.js
@@ -48,10 +48,18 @@ describe('In-memory buffer tests', () => {
     trap.submit();
 
     // Two submitted events
-    expect(trap.collectedEventCount()).toBe(2);
+    expect(trap.collectedEvents()).toHaveLength(2);
 
     // One submitted custom event
-    expect(trap.collectedEventCount((item) => item[0] === 1)).toBe(1);
+    expect(trap.collectedEvents().filter((item) => item[0] === 1))
+      .toHaveLength(1);
+
+    // Expect the collectedEvents to be a clone of the collected data
+    const evts = trap.collectedEvents();
+    // Change the event type of the first event
+    const FAKE_EVENT_TYPE = -123;
+    evts[0][0] = FAKE_EVENT_TYPE;
+    expect(trap.collectedEvents()[0][0]).not.toBe(FAKE_EVENT_TYPE);
 
     // Get the collected events in the in-memory buffer
     const collectedEvents = trap.flushCollectedEvents();

--- a/test/trap.mouse-events.test.js
+++ b/test/trap.mouse-events.test.js
@@ -60,19 +60,23 @@ describe('browser with mouse events', () => {
     });
 
     // Two, not yet submitted events
+    expect(trap.collectedEvents()).toHaveLength(2);
     expect(trap.collectedEventCount()).toBe(2);
 
     // Two mouse events
+    expect(trap.collectedEvents().filter((item) => item[0] === 0))
+      .toHaveLength(2);
     expect(trap.collectedEventCount((item) => item[0] === 0)).toBe(2);
 
     // No custom event
-    expect(trap.collectedEventCount((item) => item[0] === 1)).toBe(0);
+    expect(trap.collectedEvents().filter((item) => item[0] === 1))
+      .toHaveLength(0);
 
     // Manually trigger submit
     trap.submit();
 
     // Submitted events are not counted
-    expect(trap.collectedEventCount()).toBe(0);
+    expect(trap.collectedEvents()).toHaveLength(0);
 
     expect(fetch).toHaveBeenCalledTimes(1);
 
@@ -84,13 +88,13 @@ describe('browser with mouse events', () => {
     });
 
     // One not submitted event
-    expect(trap.collectedEventCount()).toBe(1);
+    expect(trap.collectedEvents()).toHaveLength(1);
 
     // Manually trigger submit
     trap.submit(true);
 
     // Four submitted (3 mouse + 1 header)
-    expect(trap.collectedEventCount()).toBe(0);
+    expect(trap.collectedEvents()).toHaveLength(0);
   });
 
   test('triggers mouse down and up events', () => {


### PR DESCRIPTION
This makes the collectedEventCount function deprecated, this kind of processing of the collected data should be done in the calling application.