### PR TITLE
fix: Fix epoch handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ci-trap-web",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ci-trap-web",
-      "version": "1.0.16",
+      "version": "1.0.17",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ci-trap-web",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Lightweight mouse and touch event tracker library for browsers.",
   "main": "dist/trap-umd.min.js",
   "module": "src/trap.js",

--- a/src/constants.js
+++ b/src/constants.js
@@ -69,10 +69,6 @@ export const DEFAULT_TRAP_API_KEY_NAME = 'GRABOXY-API-KEY';
 // Default API-KEY value
 export const DEFAULT_TRAP_API_KEY_VALUE = 'UNCONFIGURED';
 
-// Check `performance.timeOrigin` support
-export const PERFORMANCE_TIMEORIGIN_ENABLED =
-  typeof performance.timeOrigin === 'number';
-
 // By default, transport compression is disabled
 export const DEFAULT_TRAP_ENABLE_COMPRESSION = false;
 

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -459,6 +459,7 @@ class Handlers {
 
   // Handle window focus event: register a new event to the stream
   handleFocus(event) {
+    TimeUtils.actualizeEpoch();
     this.emit('pageStateChanged', PAGE_STATE_ACTIVE);
     this.push(
       FOCUS_WINDOW_MESSAGE_TYPE,

--- a/src/timeUtils.js
+++ b/src/timeUtils.js
@@ -8,29 +8,17 @@
 
 import simpleAutoBind from './simpleAutoBind';
 
-import {
-  PERFORMANCE_TIMEORIGIN_ENABLED,
-} from './constants';
-
 class TimeUtils {
   constructor() {
     simpleAutoBind(this);
 
     // Timestamp basis; milliseconds since the Unix epoch (1970-01-01)
-    this._epoch = PERFORMANCE_TIMEORIGIN_ENABLED
-      ? performance.timeOrigin
-      : (() => {
-        const hrSyncPoint = performance.now();
-        const unixSyncPoint = new Date().getTime();
-        return unixSyncPoint - hrSyncPoint; // timeOrigin
-      })();
+    this.actualizeEpoch();
   }
 
   // Get current timestamp
   currentTs() {
-    return (PERFORMANCE_TIMEORIGIN_ENABLED
-      ? performance.now() + this._epoch
-      : Date.now());
+    return performance.now() + this._epoch;
   }
 
   convertEventTimeToTs(timeStamp) {
@@ -39,6 +27,12 @@ class TimeUtils {
     }
 
     return timeStamp;
+  }
+
+  actualizeEpoch() {
+    const hrSyncPoint = performance.now();
+    const unixSyncPoint = new Date().getTime();
+    this._epoch = unixSyncPoint - hrSyncPoint; // timeOrigin
   }
 }
 

--- a/test/trap.time-utils.test.js
+++ b/test/trap.time-utils.test.js
@@ -1,0 +1,33 @@
+import '@testing-library/jest-dom';
+
+import timeUtils from '../src/timeUtils';
+
+describe('buffer timeout', () => {
+  beforeAll(() => {
+    // Here you must use `jest.resetModules` because otherwise Jest will have
+    // cached `trap.js` and it will _not_ run again.
+    jest.resetModules();
+
+    // Use fake timers -- it means that timers must be advanced manually!
+    jest.useFakeTimers();
+    timeUtils.actualizeEpoch();
+  });
+
+  afterAll(() => {
+    // Use real timers from now on
+    jest.useRealTimers();
+  });
+
+  test('sends chunks automatically on buffer timeout', () => {
+    const startTime = timeUtils.currentTs();
+
+    jest.advanceTimersByTime(100);
+
+    const endTime = timeUtils.currentTs();
+    timeUtils.actualizeEpoch();
+    const newEndTime = timeUtils.currentTs();
+
+    expect(endTime - startTime).toBe(100);
+    expect(endTime).toEqual(newEndTime);
+  });
+});


### PR DESCRIPTION
 On Linux and MacOS performance.now() does not increase when the computer
 sleeps. This change updates the epoch every time when the page becomes
 active ensuring that the timestamp matches the current time even when
 the computer and browser becomes active after a sleep period.

 Details about the performance.now() bug:
 https://developer.mozilla.org/en-US/docs/Web/API/Performance/now#ticking_during_sleep